### PR TITLE
Activate assembly instructions' next button after DiceKey scanned

### DIFF
--- a/DiceKeys/Views/Screens/AssemblyInstructions.swift
+++ b/DiceKeys/Views/Screens/AssemblyInstructions.swift
@@ -249,7 +249,7 @@ struct AssemblyInstructions: View {
                         step: step.rawValue,
                         prev: step.rawValue > 0 ? step.rawValue - 1 : nil,
                         next: step.rawValue + 1,
-                        setMaySkip: step == .ScanFirstTime && !userChoseToAllowSkipScanningStep ? { userChoseToAllowSkipScanningStep = true
+                        setMaySkip: step == .ScanFirstTime && self.diceKeyScanned == nil && !userChoseToAllowSkipScanningStep ? { userChoseToAllowSkipScanningStep = true
                         } :
                             nil,
                         isLastStep: step == .Done


### PR DESCRIPTION
Fix #64 

Bool that disables the "next" button and adds a "skip" button was not deactivated when a DiceKey was scanned and, having completed the AssemblyInstructions task, next should have been enabled.

Fixed by indicating that the skip button should only appear if diceKeyScanned == nil.