### PR TITLE
Ensure changes impacting UI are sent on my thread

### DIFF
--- a/DiceKeys/State/GlobalState.swift
+++ b/DiceKeys/State/GlobalState.swift
@@ -30,11 +30,11 @@ final class GlobalState: ObservableObjectUpdatingOnAllChangesToUserDefaults {
     }
     
     @Published var topLevelNavigation: TopLevelNavigateTo = .nowhere {
-        didSet { self.objectWillChange.send() }
+        didSet { self.sendChangeEventOnMainThread() }
     }
     
     @Published var diceKeyLoaded: DiceKey? = nil {
-        didSet { self.objectWillChange.send() }
+        didSet { self.sendChangeEventOnMainThread() }
     }
     
     private var cachedDiceKeyState: UnlockedDiceKeyState? = nil
@@ -58,7 +58,7 @@ final class GlobalState: ObservableObjectUpdatingOnAllChangesToUserDefaults {
         } set {
             if let derivablesJson = try? DerivationRecipe.listToJson(newValue) {
                 self.savedDerivationRecipesJson = derivablesJson
-                self.objectWillChange.send()
+                self.sendChangeEventOnMainThread()
             }
         }
     }
@@ -70,7 +70,7 @@ final class GlobalState: ObservableObjectUpdatingOnAllChangesToUserDefaults {
                 self.savedDerivationRecipes + [recipe]
             )
             .sorted(by: { a, b in a.id < b.id })
-            self.objectWillChange.send()
+            self.sendChangeEventOnMainThread()
         }
     }
 

--- a/DiceKeys/State/ObservableObjectUpdatingOnAllChangesToUserDefaults.swift
+++ b/DiceKeys/State/ObservableObjectUpdatingOnAllChangesToUserDefaults.swift
@@ -14,6 +14,12 @@ class ObservableObjectUpdatingOnAllChangesToUserDefaults: ObservableObject {
 
     init() {
         notificationSubscription = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification).sink { _ in
+            self.sendChangeEventOnMainThread()
+        }
+    }
+    
+    func sendChangeEventOnMainThread() {
+        DispatchQueue.main.async {
             self.objectWillChange.send()
         }
     }

--- a/DiceKeys/State/UnlockedDiceKeyState.swift
+++ b/DiceKeys/State/UnlockedDiceKeyState.swift
@@ -98,7 +98,7 @@ class KnownDiceKeyState: ObservableObjectUpdatingOnAllChangesToUserDefaults, Dic
 
 final class UnlockedDiceKeyState: ObservableObjectUpdatingOnAllChangesToUserDefaults, DiceKeyState {
     @Published var diceKey: DiceKey {
-        didSet { objectWillChange.send() }
+        didSet { self.sendChangeEventOnMainThread() }
     }
 
     var keyId: String {
@@ -149,7 +149,7 @@ final class UnlockedDiceKeyState: ObservableObjectUpdatingOnAllChangesToUserDefa
                 self.protectedCacheOfIsDiceKeyStored = false
                 GlobalState.instance.removeKnownDiceKey(keyId: diceKey.id)
             }
-            self.objectWillChange.send()
+            self.sendChangeEventOnMainThread()
         }
     }
 


### PR DESCRIPTION
This fixes a bug where UI updates were being made off the main thread, generating runtime warnings.

I've updated the ObservableObjectUpdatingOnAllChangesToUserDefaults, which is the root of all observable state models, so that the objectWillChange events are sent on main thread.

I've updated the GlobalState and UnlockedDiceKeyState observable objects to comply with that approach.

Please merge if you approve.