### PR TITLE
Recipe error messages

### DIFF
--- a/DiceKeys/Views/DerivationRecipes/DerivationRecipeBuilders.swift
+++ b/DiceKeys/Views/DerivationRecipes/DerivationRecipeBuilders.swift
@@ -57,7 +57,7 @@ struct DerivationRecipeBuilderForTemplate: View {
 
 private class DerivationRecipeFromUrlModel: ObservableObject {
     @ObservedObject var recipeBuilderState: RecipeBuilderState
-    @Published var urlString: String = "https://example.com" { didSet { update() } }
+    @Published var urlString: String = "" { didSet { update() } }
     @Published var sequenceNumber: Int = 1 { didSet { update() } }
     @Published var lengthInChars: Int = 0 { didSet { update() } }
     let type: DerivationOptionsType
@@ -133,13 +133,22 @@ struct DerivationRecipeForFromUrl: View {
     }
     
     var urlTextField: some View {
-        TextField("no limit", text: $model.urlString)
+        #if os(iOS)
+        return TextField("https://example.com", text: $model.urlString)
+            .disableAutocorrection(true)
+            .autocapitalization(.none)
             .font(.body)
             .multilineTextAlignment(.center)
+        #else
+        return TextField("https://example.com", text: $model.urlString)
+            .disableAutocorrection(true)
+            .font(.body)
+            .multilineTextAlignment(.center)
+        #endif
     }
     
     var lengthTextfield: some View {
-        TextField("Character Length (6 - 999)", text: lengthInCharString)
+        TextField("no limit", text: lengthInCharString)
             .font(.body)
             .multilineTextAlignment(.center)
             .padding(.top, 10)

--- a/DiceKeys/Views/DerivationRecipes/DerivationRecipeBuilders.swift
+++ b/DiceKeys/Views/DerivationRecipes/DerivationRecipeBuilders.swift
@@ -7,9 +7,15 @@
 
 import SwiftUI
 
+enum RecipeBuilderProgress {
+    case incomplete
+    case error(String)
+    case ready(DerivationRecipe)
+}
 
 class RecipeBuilderState: ObservableObject {
-    @Published var derivationRecipe: DerivationRecipe?
+    @Published var progress: RecipeBuilderProgress = .incomplete
+
     init() {}
 }
 
@@ -25,10 +31,10 @@ private class DerivationRecipeBuilderForTemplateModel: ObservableObject {
     }
 
     func update() {
-        recipeBuilderState.derivationRecipe = DerivationRecipe(
+        recipeBuilderState.progress = .ready(DerivationRecipe(
             template: template,
             sequenceNumber: sequenceNumber
-        )
+        ))
     }
 }
 
@@ -49,20 +55,20 @@ struct DerivationRecipeBuilderForTemplate: View {
     }
 }
 
-private class DerivationRecipeForFromUrlModel: ObservableObject {
+private class DerivationRecipeFromUrlModel: ObservableObject {
     @ObservedObject var recipeBuilderState: RecipeBuilderState
     @Published var urlString: String = "https://example.com" { didSet { update() } }
     @Published var sequenceNumber: Int = 1 { didSet { update() } }
     @Published var lengthInChars: Int = 0 { didSet { update() } }
     let type: DerivationOptionsType
 
-    var hosts: [String] {
-        if let host = URL(string: urlString)?.host, host != "example.com" {
+    var hosts: [String]? {
+        if let host = URL(string: urlString)?.host {
             // The field contains a valid URL from which to take a host
             return [host]
         } else if urlString.contains("/") || urlString.contains(":") {
             // The field was an invalid URL and not a list of URLs
-            return []
+            return nil
         } else {
             // Assume the field was meant to be a URL or list of URLs
             return urlString
@@ -77,13 +83,16 @@ private class DerivationRecipeForFromUrlModel: ObservableObject {
                 }
         }
     }
-    var name: String { hosts.joined(separator: ", ") }
+    var name: String { hosts?.joined(separator: ", ") ?? "" }
 
     func update() {
-        guard hosts.count > 0 else { recipeBuilderState.derivationRecipe = nil; return }
-        self.recipeBuilderState.derivationRecipe = DerivationRecipe(
+        guard let hosts = self.hosts else { recipeBuilderState.progress = .error("Field does not contain a valid URL or domain list"); return }
+        guard hosts.contains(where: { $0 != "example.com" }) else {
+            recipeBuilderState.progress = .incomplete ; return
+        }
+        self.recipeBuilderState.progress = .ready(DerivationRecipe(
             type: type, name: name,
-            derivationOptionsJson: getDerivationOptionsJson(hosts: hosts, sequenceNumber: sequenceNumber, lengthInChars: type == .Password ? lengthInChars : 0))
+            derivationOptionsJson: getDerivationOptionsJson(hosts: hosts, sequenceNumber: sequenceNumber, lengthInChars: type == .Password ? lengthInChars : 0)))
     }
 
     init(_ type: DerivationOptionsType, _ recipeBuilderState: RecipeBuilderState) {
@@ -94,7 +103,7 @@ private class DerivationRecipeForFromUrlModel: ObservableObject {
 }
 
 struct DerivationRecipeForFromUrl: View {
-    @ObservedObject private var model: DerivationRecipeForFromUrlModel
+    @ObservedObject private var model: DerivationRecipeFromUrlModel
     var lengthInCharString: Binding<String> {
         return Binding<String>(
             get: {
@@ -120,11 +129,11 @@ struct DerivationRecipeForFromUrl: View {
     }
 
     init(type: DerivationOptionsType, recipeBuilderState: RecipeBuilderState) {
-        self.model = DerivationRecipeForFromUrlModel(type, recipeBuilderState)
+        self.model = DerivationRecipeFromUrlModel(type, recipeBuilderState)
     }
     
     var urlTextField: some View {
-        TextField("URL or comma-separated list of domains", text: $model.urlString)
+        TextField("no limit", text: $model.urlString)
             .font(.body)
             .multilineTextAlignment(.center)
     }
@@ -145,12 +154,15 @@ struct DerivationRecipeForFromUrl: View {
                 urlTextField
                 #endif
                 Text("URL or comma-separated list of domains").font(.footnote).foregroundColor(.gray)
-                
+                if case let RecipeBuilderProgress.error(errorString) = model.recipeBuilderState.progress {
+                    Text(errorString).font(.footnote).foregroundColor(.red)
+                }
                 #if os(iOS)
                 lengthTextfield.keyboardType(.numberPad)
                 #else
                 lengthTextfield
                 #endif
+                Text("Maximum Character Length (6 - 999)").font(.footnote).foregroundColor(.gray)
             }
             SequenceNumberField(sequenceNumber: $model.sequenceNumber)
         }
@@ -164,9 +176,9 @@ private class DerivationRecipeForFromDerivationOptionsJsonModel: ObservableObjec
     @Published var derivationOptionsJson: String = "" { didSet { update() } }
 
     func update() {
-        self.recipeBuilderState.derivationRecipe = DerivationRecipe(
+        self.recipeBuilderState.progress = .ready(DerivationRecipe(
             type: type, name: name, derivationOptionsJson: derivationOptionsJson
-        )
+        ))
     }
 
     init(_ recipeBuilderState: RecipeBuilderState) {
@@ -204,16 +216,37 @@ struct DerivationRecipeBuilder: View {
 }
 
 struct DerivationRecipeView: View {
-    let recipe: DerivationRecipe?
-
+    let recipeBuilderProgress: RecipeBuilderProgress
+    
     var body: some View {
         VStack {
-            Text(recipe?.derivationOptionsJson ?? "{}")
-                .font(Font.system(.footnote, design: .monospaced))
-                .scaledToFit()
-                .minimumScaleFactor(0.01)
-                .fixedSize(horizontal: false, vertical: true)
-                .lineLimit(1)
+            switch (recipeBuilderProgress) {
+            case .incomplete:
+                Text("Complete the recipe above to see the output")
+                    .font(Font.system(.footnote, design: .monospaced))
+                    .foregroundColor(.gray)
+                    .scaledToFit()
+                    .minimumScaleFactor(0.01)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1)
+            case .error(let errorString):
+                Text(errorString)
+                    .font(Font.system(.footnote, design: .monospaced))
+                    .foregroundColor(.red)
+                    .scaledToFit()
+                    .minimumScaleFactor(0.01)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1)
+            case .ready(let recipe):
+                if let recipeJson = recipe.derivationOptionsJson {
+                    Text(recipeJson)
+                        .font(Font.system(.footnote, design: .monospaced))
+                        .scaledToFit()
+                        .minimumScaleFactor(0.01)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(1)
+                }
+            }
         }
     }
 }

--- a/DiceKeys/Views/Screens/DiceKeyWithDerivedValue.swift
+++ b/DiceKeys/Views/Screens/DiceKeyWithDerivedValue.swift
@@ -27,11 +27,8 @@ struct DiceKeyWithDerivedValue: View {
 //    }
 
     var derivationRecipe: DerivationRecipe? {
-//        guard let derivationRecipeBuilder = derivationRecipeBuilder else { return nil }
-        switch derivationRecipeBuilder {
-        case .recipe(let chosenRecipe): return chosenRecipe
-        default: return recipeBuilderState.derivationRecipe
-        }
+        guard case let .ready(derivationRecipe) = recipeBuilderState.progress else { return nil }
+            return derivationRecipe
     }
 
     var derivationOptionsJson: String? {
@@ -67,14 +64,11 @@ struct DiceKeyWithDerivedValue: View {
 
     var body: some View {
         VStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/, spacing: 0) {
-//            DerivationRecipeMenu({ menuOptionChosen in self.menuOptionChosen = menuOptionChosen }) { Text(derivationRecipe?.name ?? "Derive...") }
-            if let derivationRecipeBuilder = self.derivationRecipeBuilder {
+           if let derivationRecipeBuilder = self.derivationRecipeBuilder {
                 FormCard(title: "Recipe\( derivationRecipe == nil ? "" : " for \( derivationRecipe?.name ?? "" )")") {
                     VStack(alignment: .leading) {
                         if derivationRecipeBuilder.isBuilder {
-//                            Section(header: Text("Settings").font(.title2) ) {
                             DerivationRecipeBuilder(derivableMenuChoice: derivationRecipeBuilder, recipeBuilderState: recipeBuilderState)
-//                            }
                         }
                         Divider().hideIf(derivationRecipe == nil)
                         Text("Internal representation of your recipe").hideIf(derivationRecipe == nil)
@@ -83,7 +77,7 @@ struct DiceKeyWithDerivedValue: View {
                             .minimumScaleFactor(0.01)
                             .fixedSize(horizontal: false, vertical: true)
                             .lineLimit(1)
-                        DerivationRecipeView(recipe: derivationRecipe).padding(.top, 3).hideIf(derivationRecipe == nil)
+                        DerivationRecipeView(recipeBuilderProgress: self.recipeBuilderState.progress).padding(.top, 3)
                         Divider()
                         HStack {
                             Spacer()
@@ -107,7 +101,6 @@ struct DiceKeyWithDerivedValue: View {
                                 .font(.body)
                                 .multilineTextAlignment(.center)
                                 .lineLimit(2)
-    //                            .scaledToFit()
                                 .minimumScaleFactor(0.1)
                                 .fixedSize(horizontal: false, vertical: true)
                                 .padding(.horizontal, 5)


### PR DESCRIPTION
Add a label beneath the recipe length field.
When recipe length field is empty, put "none" in it.
Remove auto-capitalization on url/host field
Remove auto-correction on url/host field (ios only, not a problem on Mac)
Make "https://example.com" demo text in url/host field, not actual content