### PR TITLE
#36 fix - changing file type on cocoapods post_integrate hook

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,6 +27,21 @@ abstract_target 'DiceKeys' do
       inherit! :complete
     end
   end
+
+  post_integrate do |installer|
+    file_name = project_file = "Pods/Pods.xcodeproj/project.pbxproj"
+    lines = File.readlines(file_name)
+    for line in lines
+      if line.include?( "opencv2.xcframework/ios-arm64_armv7/opencv2.framework/Versions/A/Headers/Core.h") and line.include?("lastKnownFileType = sourcecode.c.h")
+          line.sub!("lastKnownFileType = sourcecode.c.h", "explicitFileType = sourcecode.c.objc")
+          f = File.open(file_name, "w")
+          f << lines.join("\n")
+          f.close
+        break
+      end
+    end
+  end
+
 end
 
 #target 'DiceKeys (macOS)' do


### PR DESCRIPTION
Hackish way to change source code file type by editing pbxproj file manually on Cocoapods post_integrate hook

fixes #36 