### PR TITLE
#135 Add command-line tool for seeding that does't require Big Sur

### DIFF
--- a/DiceKeys.xcodeproj/project.pbxproj
+++ b/DiceKeys.xcodeproj/project.pbxproj
@@ -132,9 +132,14 @@
 		2669052E25C17AC60078CF55 /* FacesReadOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2669050B25C16B610078CF55 /* FacesReadOverlayModel.swift */; };
 		268E3DDD25BFF81D008B6DE6 /* CameraFrameCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268E3DDC25BFF81D008B6DE6 /* CameraFrameCountView.swift */; };
 		268E3DDE25BFF81D008B6DE6 /* CameraFrameCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268E3DDC25BFF81D008B6DE6 /* CameraFrameCountView.swift */; };
+		5AA7518A0EB3CE7BA918EA37 /* Pods_DiceKeys_seed_security_key.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11B47B56FAA800AB6DE64728 /* Pods_DiceKeys_seed_security_key.framework */; };
 		C12763A084D675535C4C583C /* Pods_DiceKeys_DiceKeys__iOS__Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE730BB0AD520FB48D20673B /* Pods_DiceKeys_DiceKeys__iOS__Tests_iOS.framework */; };
 		C3191A6507C20AF840F4054E /* Pods_DiceKeys_DiceKeys__iOS_.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 061985777EDBE015A8A6CD60 /* Pods_DiceKeys_DiceKeys__iOS_.framework */; };
 		D47C9F2B23F56353525EA408 /* Pods_DiceKeys_DiceKeys__macOS__Tests_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1397E5F18A65098140DBC5BB /* Pods_DiceKeys_DiceKeys__macOS__Tests_macOS.framework */; };
+		EC1DF9FA261B22BF00A3C726 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1DF9F9261B22BF00A3C726 /* main.swift */; };
+		EC1DFA03261B22CD00A3C726 /* CtapHidConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6C5A025A43AAB007798F3 /* CtapHidConnection.swift */; };
+		EC1DFA09261B22D200A3C726 /* AttachedHidDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6C5AA25A494CB007798F3 /* AttachedHidDevice.swift */; };
+		EC1DFA0A261B22D700A3C726 /* AttachedHidDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B6C62625B58252007798F3 /* AttachedHidDevices.swift */; };
 		EC5091EF259480BE007D2B91 /* UnlockedDiceKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5091EB259480BE007D2B91 /* UnlockedDiceKeyState.swift */; };
 		EC5091F0259480BE007D2B91 /* UnlockedDiceKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5091EB259480BE007D2B91 /* UnlockedDiceKeyState.swift */; };
 		EC5091F1259480BE007D2B91 /* ObservableObjectUpdatingOnAllChangesToUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5091EC259480BE007D2B91 /* ObservableObjectUpdatingOnAllChangesToUserDefaults.swift */; };
@@ -270,8 +275,21 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		EC1DF9F5261B22BF00A3C726 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		061985777EDBE015A8A6CD60 /* Pods_DiceKeys_DiceKeys__iOS_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DiceKeys_DiceKeys__iOS_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11B47B56FAA800AB6DE64728 /* Pods_DiceKeys_seed_security_key.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DiceKeys_seed_security_key.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1397E5F18A65098140DBC5BB /* Pods_DiceKeys_DiceKeys__macOS__Tests_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DiceKeys_DiceKeys__macOS__Tests_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14C38080E39571B13473B619 /* Pods-DiceKeys (iOS).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys (iOS).release.xcconfig"; path = "Target Support Files/Pods-DiceKeys (iOS)/Pods-DiceKeys (iOS).release.xcconfig"; sourceTree = "<group>"; };
 		172057B025C2DBF800282E21 /* SupportsBackNavigationHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportsBackNavigationHeader.swift; sourceTree = "<group>"; };
@@ -310,6 +328,7 @@
 		2669050125C16B300078CF55 /* CameraFrameCountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraFrameCountModel.swift; sourceTree = "<group>"; };
 		2669050B25C16B610078CF55 /* FacesReadOverlayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacesReadOverlayModel.swift; sourceTree = "<group>"; };
 		268E3DDC25BFF81D008B6DE6 /* CameraFrameCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraFrameCountView.swift; sourceTree = "<group>"; };
+		2DAA8D1E1D57C9C5AD89A4B9 /* Pods-DiceKeys-seed-security-key.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys-seed-security-key.debug.xcconfig"; path = "Target Support Files/Pods-DiceKeys-seed-security-key/Pods-DiceKeys-seed-security-key.debug.xcconfig"; sourceTree = "<group>"; };
 		349BE82A357ED684A2430E54 /* Pods-DiceKeys-DiceKeys (iOS)-Tests iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys-DiceKeys (iOS)-Tests iOS.debug.xcconfig"; path = "Target Support Files/Pods-DiceKeys-DiceKeys (iOS)-Tests iOS/Pods-DiceKeys-DiceKeys (iOS)-Tests iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		81E686DCFFCE5769AB6D0DF8 /* Pods_DiceKeys_DiceKeys__macOS_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DiceKeys_DiceKeys__macOS_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A12F40698764C98F698C6350 /* Pods-DiceKeys (macOS).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys (macOS).release.xcconfig"; path = "Target Support Files/Pods-DiceKeys (macOS)/Pods-DiceKeys (macOS).release.xcconfig"; sourceTree = "<group>"; };
@@ -317,6 +336,9 @@
 		BE730BB0AD520FB48D20673B /* Pods_DiceKeys_DiceKeys__iOS__Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DiceKeys_DiceKeys__iOS__Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6328E5B71C2EFE82AB1D100 /* Pods-DiceKeys (iOS).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys (iOS).debug.xcconfig"; path = "Target Support Files/Pods-DiceKeys (iOS)/Pods-DiceKeys (iOS).debug.xcconfig"; sourceTree = "<group>"; };
 		D7A6CFB76A8652A22F05944F /* Pods-DiceKeys-DiceKeys (macOS)-Tests macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys-DiceKeys (macOS)-Tests macOS.debug.xcconfig"; path = "Target Support Files/Pods-DiceKeys-DiceKeys (macOS)-Tests macOS/Pods-DiceKeys-DiceKeys (macOS)-Tests macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		EAEB08449EB22F303DCDF2C6 /* Pods-DiceKeys-seed-security-key.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DiceKeys-seed-security-key.release.xcconfig"; path = "Target Support Files/Pods-DiceKeys-seed-security-key/Pods-DiceKeys-seed-security-key.release.xcconfig"; sourceTree = "<group>"; };
+		EC1DF9F7261B22BF00A3C726 /* seed-security-key */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "seed-security-key"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC1DF9F9261B22BF00A3C726 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		EC5091EB259480BE007D2B91 /* UnlockedDiceKeyState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnlockedDiceKeyState.swift; sourceTree = "<group>"; };
 		EC5091EC259480BE007D2B91 /* ObservableObjectUpdatingOnAllChangesToUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableObjectUpdatingOnAllChangesToUserDefaults.swift; sourceTree = "<group>"; };
 		EC5091F925948124007D2B91 /* DiceKeyMedium.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiceKeyMedium.swift; sourceTree = "<group>"; };
@@ -395,6 +417,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		EC1DF9F4261B22BF00A3C726 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5AA7518A0EB3CE7BA918EA37 /* Pods_DiceKeys_seed_security_key.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EC561281258B827300A056B8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -500,6 +530,8 @@
 				FADE66DE7171550A3CEADF50 /* Pods-DiceKeys-DiceKeys (macOS).release.xcconfig */,
 				D7A6CFB76A8652A22F05944F /* Pods-DiceKeys-DiceKeys (macOS)-Tests macOS.debug.xcconfig */,
 				2041EA96DFD46E6AA469E4E3 /* Pods-DiceKeys-DiceKeys (macOS)-Tests macOS.release.xcconfig */,
+				2DAA8D1E1D57C9C5AD89A4B9 /* Pods-DiceKeys-seed-security-key.debug.xcconfig */,
+				EAEB08449EB22F303DCDF2C6 /* Pods-DiceKeys-seed-security-key.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -511,8 +543,17 @@
 				BE730BB0AD520FB48D20673B /* Pods_DiceKeys_DiceKeys__iOS__Tests_iOS.framework */,
 				81E686DCFFCE5769AB6D0DF8 /* Pods_DiceKeys_DiceKeys__macOS_.framework */,
 				1397E5F18A65098140DBC5BB /* Pods_DiceKeys_DiceKeys__macOS__Tests_macOS.framework */,
+				11B47B56FAA800AB6DE64728 /* Pods_DiceKeys_seed_security_key.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EC1DF9F8261B22BF00A3C726 /* seed-security-key */ = {
+			isa = PBXGroup;
+			children = (
+				EC1DF9F9261B22BF00A3C726 /* main.swift */,
+			);
+			path = "seed-security-key";
 			sourceTree = "<group>";
 		};
 		EC5091E9259480BE007D2B91 /* State */ = {
@@ -738,6 +779,7 @@
 				EC56128D258B827300A056B8 /* macOS */,
 				EC561297258B827300A056B8 /* Tests iOS */,
 				EC5612A2258B827300A056B8 /* Tests macOS */,
+				EC1DF9F8261B22BF00A3C726 /* seed-security-key */,
 				EC561285258B827300A056B8 /* Products */,
 				8BCE0DBCE05C749853CDC99E /* Pods */,
 				E3C92F6F84F8D8E47D8983A4 /* Frameworks */,
@@ -766,6 +808,7 @@
 				EC56128C258B827300A056B8 /* DiceKeys.app */,
 				EC561294258B827300A056B8 /* Tests iOS.xctest */,
 				EC56129F258B827300A056B8 /* Tests macOS.xctest */,
+				EC1DF9F7261B22BF00A3C726 /* seed-security-key */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -808,6 +851,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		EC1DF9F6261B22BF00A3C726 /* seed-security-key */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EC1DF9FD261B22BF00A3C726 /* Build configuration list for PBXNativeTarget "seed-security-key" */;
+			buildPhases = (
+				FB1FE1EF73C4714B152559FA /* [CP] Check Pods Manifest.lock */,
+				EC1DF9F3261B22BF00A3C726 /* Sources */,
+				EC1DF9F4261B22BF00A3C726 /* Frameworks */,
+				EC1DF9F5261B22BF00A3C726 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "seed-security-key";
+			productName = "seed-security-key";
+			productReference = EC1DF9F7261B22BF00A3C726 /* seed-security-key */;
+			productType = "com.apple.product-type.tool";
+		};
 		EC561283258B827300A056B8 /* DiceKeys (iOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EC5612AE258B827300A056B8 /* Build configuration list for PBXNativeTarget "DiceKeys (iOS)" */;
@@ -892,9 +953,12 @@
 		EC561278258B827200A056B8 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1230;
+				LastSwiftUpdateCheck = 1240;
 				LastUpgradeCheck = 1230;
 				TargetAttributes = {
+					EC1DF9F6261B22BF00A3C726 = {
+						CreatedOnToolsVersion = 12.4;
+					};
 					EC561283258B827300A056B8 = {
 						CreatedOnToolsVersion = 12.3;
 					};
@@ -928,6 +992,7 @@
 				EC56128B258B827300A056B8 /* DiceKeys (macOS) */,
 				EC561293258B827300A056B8 /* Tests iOS */,
 				EC56129E258B827300A056B8 /* Tests macOS */,
+				EC1DF9F6261B22BF00A3C726 /* seed-security-key */,
 			);
 		};
 /* End PBXProject section */
@@ -1082,6 +1147,28 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		FB1FE1EF73C4714B152559FA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-DiceKeys-seed-security-key-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		FBEBC188D4E208EB7186F394 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1129,6 +1216,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		EC1DF9F3261B22BF00A3C726 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EC1DF9FA261B22BF00A3C726 /* main.swift in Sources */,
+				EC1DFA0A261B22D700A3C726 /* AttachedHidDevices.swift in Sources */,
+				EC1DFA03261B22CD00A3C726 /* CtapHidConnection.swift in Sources */,
+				EC1DFA09261B22D200A3C726 /* AttachedHidDevice.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EC561280258B827300A056B8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1409,6 +1507,30 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		EC1DF9FB261B22BF00A3C726 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2DAA8D1E1D57C9C5AD89A4B9 /* Pods-DiceKeys-seed-security-key.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		EC1DF9FC261B22BF00A3C726 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EAEB08449EB22F303DCDF2C6 /* Pods-DiceKeys-seed-security-key.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		EC5612AC258B827300A056B8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1727,6 +1849,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		EC1DF9FD261B22BF00A3C726 /* Build configuration list for PBXNativeTarget "seed-security-key" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EC1DF9FB261B22BF00A3C726 /* Debug */,
+				EC1DF9FC261B22BF00A3C726 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		EC56127B258B827200A056B8 /* Build configuration list for PBXProject "DiceKeys" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Podfile
+++ b/Podfile
@@ -9,13 +9,16 @@ abstract_target 'DiceKeys' do
 
   pod 'SwiftLint'
 
-  # Pods for DiceKeys
-  pod 'SeededCrypto', :git => 'https://github.com/dicekeys/seeded-crypto-ios.git', :submodules => true, :branch => 'replace-all-derivation-options-with-recipe'
-  pod 'OpenCVXF', :git => 'https://github.com/dicekeys/opencv-xf.git'
-  pod "ReadDiceKey", :git => 'https://github.com/dicekeys/read-dicekey-ios.git', :submodules => true
+  def shared_pods
+    # Pods for DiceKeys
+    pod 'SeededCrypto', :git => 'https://github.com/dicekeys/seeded-crypto-ios.git', :submodules => true, :branch => 'replace-all-derivation-options-with-recipe'
+    pod 'OpenCVXF', :git => 'https://github.com/dicekeys/opencv-xf.git'
+    pod "ReadDiceKey", :git => 'https://github.com/dicekeys/read-dicekey-ios.git', :submodules => true
+  end
 
   target 'DiceKeys (iOS)' do
     platform :ios, '14.0'
+    shared_pods
     target 'Tests iOS' do
       inherit! :complete
     end
@@ -23,9 +26,14 @@ abstract_target 'DiceKeys' do
   
   target 'DiceKeys (macOS)' do
     platform :osx, '11.0'
+    shared_pods
     target 'Tests macOS' do
       inherit! :complete
     end
+  end
+
+  target 'seed-security-key' do
+    platform :osx, '10.15'
   end
 
   post_integrate do |installer|

--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ pod install
 To test the app, you'll need a DiceKey, which is a box of 25 dice, to scan using the camera.
 
 If you don't have a DiceKey, go to https://dicekeys.app, use the feature to generate a random DiceKey, and then print a picture of arrangement of 25 dice to scan from the app. (Or, you can just scan them from one device's screen to another device's camera.
+
+## Security Key Seed Writer
+
+The command-line utility writes a 32-byte seed to a security key for use with [DiceKeys/SoloKeys standard for seeding authenticators](https://github.com/dicekeys/seeding-webauthn).
+
+It takes one parameter: a hex format 32-byte seed (64 hex characters) optionally preceded by "0x".  For example, for seed `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`:
+
+```
+seed-security-key 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+```
+
+ (DO NOT USE THE ABOVE SEED!)

--- a/seed-security-key/main.swift
+++ b/seed-security-key/main.swift
@@ -1,0 +1,74 @@
+//
+//  main.swift
+//  DiceKeys (Terminal)
+//
+//  Created by bakhtiyor on 05/04/21.
+//
+
+import Foundation
+
+let arguments = CommandLine.arguments
+if arguments.count >= 2 {
+  let seed = arguments[1]
+  if let seedAs32bytes = seed.data(using: .hexadecimal), seedAs32bytes.count == 32 {
+    print("Seed set to \(seed).")
+    let securityKeys: [AttachedHidDevice] = AttachedHidDevices.singleton.connectedDevices
+    if securityKeys.count > 0 {
+      let securityKey = securityKeys[0]
+      let semaphore = DispatchSemaphore(value: 0)
+      
+      securityKey.writeSecurityKeySeed(keySeedAs32Bytes: seedAs32bytes) { (result) in
+        switch (result) {
+        case .failure(let err):
+          switch err {
+          case .couldNotOpenDevice:
+            print("Error: could not open device.")
+          case .invalidSeedLength:
+            print("Error: invalid seed length.")
+          case .couldNotGenerateRandomNonce:
+            print("Error: could not generate random nonce.")
+          case .errorReturned(let errMessage):
+            print("Error: code \([UInt8](errMessage)).")
+          }
+        default: print("Success.")
+        }
+        semaphore.signal()
+      }
+      
+      _ = semaphore.wait(timeout: .distantFuture)
+    } else {
+      print("No devices.")
+    }
+  } else {
+    print("Input data should be 32 bytes as a hexademical digit.")
+  }
+} else {
+  print("No seed provided.")
+}
+
+// ----------------------------------------------------------------
+
+extension String {
+  enum ExtendedEncoding {
+    case hexadecimal
+  }
+  
+  func data(using encoding:ExtendedEncoding) -> Data? {
+    let hexStr = self.dropFirst(self.hasPrefix("0x") ? 2 : 0)
+    
+    guard hexStr.count % 2 == 0 else { return nil }
+    
+    var newData = Data(capacity: hexStr.count/2)
+    
+    var indexIsEven = true
+    for i in hexStr.indices {
+      if indexIsEven {
+        let byteRange = i...hexStr.index(after: i)
+        guard let byte = UInt8(hexStr[byteRange], radix: 16) else { return nil }
+        newData.append(byte)
+      }
+      indexIsEven.toggle()
+    }
+    return newData
+  }
+}

--- a/seed-security-key/main.swift
+++ b/seed-security-key/main.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 let arguments = CommandLine.arguments
+
 if arguments.count >= 2 {
   let seed = arguments[1]
   if let seedAs32bytes = seed.data(using: .hexadecimal), seedAs32bytes.count == 32 {
@@ -20,16 +21,7 @@ if arguments.count >= 2 {
       securityKey.writeSecurityKeySeed(keySeedAs32Bytes: seedAs32bytes) { (result) in
         switch (result) {
         case .failure(let err):
-          switch err {
-          case .couldNotOpenDevice:
-            print("Error: could not open device.")
-          case .invalidSeedLength:
-            print("Error: invalid seed length.")
-          case .couldNotGenerateRandomNonce:
-            print("Error: could not generate random nonce.")
-          case .errorReturned(let errMessage):
-            print("Error: code \([UInt8](errMessage)).")
-          }
+          printErrorMessage(err)
         default: print("Success.")
         }
         semaphore.signal()
@@ -44,6 +36,19 @@ if arguments.count >= 2 {
   }
 } else {
   print("No seed provided.")
+}
+
+fileprivate func printErrorMessage(_ err: (CtapRequestError)) {
+  switch err {
+  case .couldNotOpenDevice:
+    print("Error: could not open device.")
+  case .invalidSeedLength:
+    print("Error: invalid seed length.")
+  case .couldNotGenerateRandomNonce:
+    print("Error: could not generate random nonce.")
+  case .errorReturned(let errMessage):
+    print("Error: code \([UInt8](errMessage)).")
+  }
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
New build target added - "seed-security-key" for the command line utility